### PR TITLE
[alpine_mobile/#3297] Eliminate warnings from package.json for missing repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   "homepage": "",
   "author": "",
   "description": "",
-  "private": false
+  "private": true
 }
 


### PR DESCRIPTION
- adding private: true to package.json
